### PR TITLE
Support fot multiline text via line-breaks

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -166,7 +166,24 @@ class Render {
       attr["text-anchor"] = translate[text.vars.textAlign];
     }
 
-    return svg('text', attr, text.vars.text);
+    var lines = text.vars.text.split("\n");
+    var children = [];
+    var deltaY;
+    for (var i=0; i<lines.length; i++){
+      if (i === 0){
+        deltaY = "0em";
+      }else{
+        deltaY = "1.2em";
+
+        if(text.vars.lineHeight){
+          deltaY = text.vars.lineHeight;
+        }
+      }
+      var child = svg('tspan', {x: attr.x, dy: deltaY}, lines[i]);
+      children.push(child);
+    }
+
+    return svg('text', attr, children);
   }
 
   imageToSVG(img) {

--- a/src/shapes/text.js
+++ b/src/shapes/text.js
@@ -24,6 +24,7 @@ class Text {
   fontSize(fontSize) { this.vars.fontSize = fontSize; return this; }
   letterSpacing(letterSpacing) { this.vars.letterSpacing = letterSpacing; return this; }
   textDecoration(textDecoration) { this.vars.textDecoration = textDecoration; return this; }
+  lineHeight(lineHeight) { this.vars.lineHeight = lineHeight; return this; }
 
   copy(parent) {
     var copy = new Text();
@@ -35,6 +36,7 @@ class Text {
     copy.vars.fontSize = this.vars.fontSize;
     copy.vars.letterSpacing = this.vars.letterSpacing;
     copy.vars.textDecoration = this.vars.textDecoration;
+    copy.vars.lineHeight = this.vars.lineHeight;
     Utils.copyMixinVars(this, copy);
     Utils.groupLogic(copy, this.parent, parent);
     return copy;


### PR DESCRIPTION
As mentioned in #8 

For what I'm doing, I just need it to recognise line breaks in JS strings so that's what I implemented here. Word wrap is way too complicated for me to do at the moment.

The new addition also adds a new `lineHeight()` function for defining line height, default is 1.2em but it should accept whatever unit svg accepts.
