### PR TITLE
Add xmlns namespace values to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Follow [@runemadsen](https://twitter.com/runemadsen) for announcements.
 
 1. Clone down this repo
 2. Run `npm install` from the repo folder
-3. Run `gulp test`
+3. Run `gulp test:headless`, `gulp test:browser` and/or `gulp test:node`
 
 

--- a/src/render.js
+++ b/src/render.js
@@ -15,6 +15,8 @@ class Render {
   constructor(params) {
     this.params = params
     this.tree = svg('svg', {
+      xmlns: 'http://www.w3.org/2000/svg',
+      'xmlns:xlink': 'http://www.w3.org/1999/xlink',
       width: this.s(params.width),
       height: this.s(params.height)
     });


### PR DESCRIPTION
First of all, thanks for making this library. This is a naive PR as I've only spent an hour or so with the library.

I added the `xmlns` attributes to the `svg` element so that copy/pasting output and saving to a file, the svgs are recognized by Mac OS as images and will preview.

Also I updated the readme to reflect the current test suite.