### PR TITLE
Add rounding code to prevent inconsistencies between browsers

### DIFF
--- a/src/vector.js
+++ b/src/vector.js
@@ -72,8 +72,8 @@ class Vector {
   rotate(degrees) {
     var rad = Utils.radians(this.rotation() + degrees);
     var len = this.length();
-    var x = Math.cos(rad) * len;
-    var y = Math.sin(rad) * len;
+    var x = Math.round(Math.cos(rad) * len);
+    var y = Math.round(Math.sin(rad) * len);
     return new Vector(x, y);
   }
 


### PR DESCRIPTION
This should probably be fixed in more places, but it fixes the test which fails in Safari for now. It's the Vector.rotate test.
Another option would be to set the amount of precision that the x and y properties are limited to for vectors upon initialization.