### PR TITLE
Rounding precision fix for vector rotation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,10 @@ var Utils = {
     if(a.moveable && b.moveable)    b.moveable(a);
     if(a.sizeable && b.sizeable)    b.sizeable(a);
     if(a.styleable && b.styleable)  b.styleable(a);
+  },
+
+  round: function(value, decimals) {
+    return Number(Math.round(value+'e'+decimals)+'e-'+decimals);
   }
 
 };

--- a/src/vector.js
+++ b/src/vector.js
@@ -1,7 +1,8 @@
 import Utils from './utils'
 
-class Vector {
+var ROUND_PRECISION = 9;
 
+class Vector {
   constructor(x, y) {
     this.x = x || 0;
     this.y = y || 0;
@@ -72,8 +73,8 @@ class Vector {
   rotate(degrees) {
     var rad = Utils.radians(this.rotation() + degrees);
     var len = this.length();
-    var x = Math.round(Math.cos(rad) * len);
-    var y = Math.round(Math.sin(rad) * len);
+    var x = Utils.round(Math.cos(rad) * len, ROUND_PRECISION);
+    var y = Utils.round(Math.sin(rad) * len, ROUND_PRECISION);
     return new Vector(x, y);
   }
 

--- a/src/vector.js
+++ b/src/vector.js
@@ -72,8 +72,8 @@ class Vector {
   rotate(degrees) {
     var rad = Utils.radians(this.rotation() + degrees);
     var len = this.length();
-    var x = Math.cos(rad) * len;
-    var y = Math.sin(rad) * len;
+    var x = Math.round(Math.cos(rad) * len);
+    var y = Math.round(Math.sin(rad) * len);
     return new Vector(x, y);
   }
 


### PR DESCRIPTION
I've got an improved solution to the problem of inconsistencies between browsers. In Safari, the Vector.rotate test was failing, due to a rounding difference. I added a function to the Utils object which consistently rounds number to a given precision. Then, in the Vector class, I round the results of the x,y rotate with a precision of 9 decimal places.