### PR TITLE
Tentative fix to namespace attribute issue

### DIFF
--- a/src/rune.js
+++ b/src/rune.js
@@ -53,7 +53,11 @@ var Rune = function(options) {
     this.height = params.height;
   }
 
-  this.tree = svg('svg', attrs);
+  var props = {
+      attributes: attrs
+  }
+  
+  this.tree = svg('svg', props);
   this.el = createElement(this.tree);
   this.stage = new Group();
   this.debug = params.debug;
@@ -249,7 +253,11 @@ Rune.prototype = {
     if(!this.ignoreWidth)  attrs.width = Utils.s(this.width);
     if(!this.ignoreHeight) attrs.height = Utils.s(this.height);
 
-    var newTree = svg('svg', attrs, [this.stage.renderChildren({ debug: this.debug })]);
+    var props = {
+       attributes: attrs
+    }
+    
+    var newTree = svg('svg', props, [this.stage.renderChildren({ debug: this.debug })]);
     var diffTree = diff(this.tree, newTree);
     this.el = patch(this.el, diffTree);
     this.tree = newTree;

--- a/test/shared/rune.js
+++ b/test/shared/rune.js
@@ -13,6 +13,12 @@ describe("Rune", function() {
       expect(r.width).toEqual(100);
       expect(r.height).toEqual(105);
     });
+    
+    it("should define namespace in attributes", function() {
+        var r = new Rune();
+        expect(r.tree.properties.attributes.xmlns).not.toEqual(undefined);
+        expect(r.tree.properties.attributes['xmlns:xlink']).not.toEqual(undefined);
+    });
 
   });
 


### PR DESCRIPTION
Fix to #16. I thought it might make more sense to make a "props" variable to match the "properties" inside the svg() function. I replaced it where I found the namespace attributes defined.  
