### PR TITLE
Update alpha value on rgba input. This fixes #44

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -38,7 +38,7 @@ var Color = function(a, b, c, d, e) {
   } else if (typeof a !== "undefined") {
     // RGB
     this.setValues("rgb", { r: a, g: b, b: c });
-    if (d) this.setValues("alpha", d);
+    if (typeof d !== "undefined") this.setValues("alpha", d);
   }
 };
 


### PR DESCRIPTION
Updated so `0` values are not excluded form the condition, now a `.fill()` input like this will have the expected behaviour:
```javascript
r.rect(0, 0, 100, 100).fill(255, 0, 0, 0);
```